### PR TITLE
[bug_fix]]当命令输出为空时，发送命令记录出错

### DIFF
--- a/jms/service.py
+++ b/jms/service.py
@@ -348,7 +348,7 @@ class AppService(ApiRequest):
         if isinstance(data, dict):
             data = [data]
         for d in data:
-            if d.get('output') and not isinstance(d['output'], bytes):
+            if not isinstance(d['output'], bytes):
                 d['output'] = d['output'].encode('utf-8')
             d['output'] = base64.b64encode(d['output']).decode("utf-8")
         result, content = self.post('send-command-log', data=data)


### PR DESCRIPTION
当执行命令的输出为空字符串时（如mkdir），351行条件判断会跳过将空字符串转为为bytestring，然后在353行报错。